### PR TITLE
Update telegraf js to 4.3.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dotenv": "^8.2.0",
     "module-alias": "^2.2.2",
     "mongoose": "5.10.18",
-    "telegraf": "^3.38.0",
+    "telegraf": "^4.3.0",
     "telegraf-i18n": "^6.6.0",
     "typescript": "^4.2.3"
   },

--- a/src/commands/language.ts
+++ b/src/commands/language.ts
@@ -1,33 +1,32 @@
-import { Telegraf, Context, Markup as m, Extra } from 'telegraf'
+import { Telegraf, Context, Markup as m } from 'telegraf'
 import { readdirSync, readFileSync } from 'fs'
 import { safeLoad } from 'js-yaml'
-import { ExtraEditMessage } from 'telegraf/typings/telegram-types'
 
 export function setupLanguage(bot: Telegraf<Context>) {
   bot.command('language', (ctx) => {
-    ctx.reply(ctx.i18n.t('language'), {
-      reply_markup: languageKeyboard(),
-    })
+    ctx.reply(ctx.i18n.t('language'), languageKeyboard())
   })
 
   bot.action(
     localesFiles().map((file) => file.split('.')[0]),
-    async (ctx) => {
+    async (ctx: Context) => {
       let user = ctx.dbuser
-      user.language = ctx.callbackQuery.data
-      user = await (user as any).save()
-      const message = ctx.callbackQuery.message
+      if ("data" in ctx.callbackQuery) {
+        user.language = ctx.callbackQuery.data
+        user = await (user as any).save()
+        const message = ctx.callbackQuery.message
 
-      const anyI18N = ctx.i18n as any
-      anyI18N.locale(ctx.callbackQuery.data)
+        const anyI18N = ctx.i18n as any
+        anyI18N.locale(ctx.callbackQuery.data)
 
-      await ctx.telegram.editMessageText(
-        message.chat.id,
-        message.message_id,
-        undefined,
-        ctx.i18n.t('language_selected'),
-        Extra.HTML(true) as ExtraEditMessage
-      )
+        await ctx.telegram.editMessageText(
+            message.chat.id,
+            message.message_id,
+            undefined,
+            ctx.i18n.t('language_selected'),
+            {parse_mode: 'HTML'}
+        )
+      }
     }
   )
 }
@@ -42,12 +41,12 @@ function languageKeyboard() {
     ).name
     if (index % 2 == 0) {
       if (index === 0) {
-        result.push([m.callbackButton(localeName, localeCode)])
+        result.push([m.button.callback(localeName, localeCode)])
       } else {
-        result[result.length - 1].push(m.callbackButton(localeName, localeCode))
+        result[result.length - 1].push(m.button.callback(localeName, localeCode))
       }
     } else {
-      result[result.length - 1].push(m.callbackButton(localeName, localeCode))
+      result[result.length - 1].push(m.button.callback(localeName, localeCode))
       if (index < locales.length - 1) {
         result.push([])
       }

--- a/src/helpers/i18n.ts
+++ b/src/helpers/i18n.ts
@@ -1,5 +1,5 @@
 import I18N from 'telegraf-i18n'
-import Telegraf, { Context } from 'telegraf'
+import { Telegraf, Context } from 'telegraf'
 const dirtyI18N = require('telegraf-i18n')
 
 const i18n = new dirtyI18N({
@@ -15,6 +15,6 @@ export function setupI18N(bot: Telegraf<Context>) {
   bot.use((ctx, next) => {
     const anyI18N = ctx.i18n as any
     anyI18N.locale(ctx.dbuser.language)
-    next()
+    return next()
   })
 }

--- a/src/middlewares/attachUser.ts
+++ b/src/middlewares/attachUser.ts
@@ -1,8 +1,7 @@
-import { findUser } from '../models'
+import { findUser } from '@/models'
 import { Context } from 'telegraf'
 
 export async function attachUser(ctx: Context, next) {
-  const dbuser = await findUser(ctx.from.id)
-  ctx.dbuser = dbuser
+  ctx.dbuser = await findUser(ctx.from.id)
   return next()
 }

--- a/src/types/telegraf.d.ts
+++ b/src/types/telegraf.d.ts
@@ -1,20 +1,10 @@
 import I18N from 'telegraf-i18n'
-import { User } from '../models'
+import { User } from '@/models'
 import { DocumentType } from '@typegoose/typegoose'
-import { Middleware } from 'telegraf'
-import { TelegrafContext } from 'telegraf/typings/context'
 
 declare module 'telegraf' {
   export class Context {
     dbuser: DocumentType<User>
     i18n: I18N
-  }
-
-  export interface Composer<TContext extends Context> {
-    action(
-      action: string | string[] | RegExp,
-      middleware: Middleware<TelegrafContext>,
-      ...middlewares: Array<Middleware<TelegrafContext>>
-    ): Composer<TContext>
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -186,6 +193,24 @@ bson@^1.1.4:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.6.tgz#fb819be9a60cd677e0853aee4ca712a785d6618a"
   integrity sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==
+
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
+  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
 cacheable-request@^6.0.0:
   version "6.1.0"
@@ -368,7 +393,7 @@ debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1:
+debug@^4.0.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -457,6 +482,11 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -781,7 +811,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0:
+minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -857,7 +887,7 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-node-fetch@^2.2.0:
+node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -916,6 +946,11 @@ p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
+p-timeout@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-4.1.0.tgz#788253c0452ab0ffecf18a62dff94ff1bd09ca0a"
+  integrity sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==
 
 package-json@^6.3.0:
   version "6.5.0"
@@ -1091,7 +1126,14 @@ safe-buffer@5.2.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-sandwich-stream@^2.0.1:
+safe-compare@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/safe-compare/-/safe-compare-1.1.4.tgz#5e0128538a82820e2e9250cd78e45da6786ba593"
+  integrity sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==
+  dependencies:
+    buffer-alloc "^1.2.0"
+
+sandwich-stream@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/sandwich-stream/-/sandwich-stream-2.0.2.tgz#6d1feb6cf7e9fe9fadb41513459a72c2e84000fa"
   integrity sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==
@@ -1259,22 +1301,20 @@ telegraf-i18n@^6.6.0:
     debug "^4.0.1"
     js-yaml "^3.6.1"
 
-telegraf@^3.38.0:
-  version "3.38.0"
-  resolved "https://registry.yarnpkg.com/telegraf/-/telegraf-3.38.0.tgz#745b447547a8e6cdb626055e4d616058aaae0759"
-  integrity sha512-va4VlrKWp64JrowFoZX/NPzzA6q38kvaIukVXOWFO1V+jR1G8+hCfgJy4TX8Z3rwLJzwaBEet1QhikHDRZWl3A==
+telegraf@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/telegraf/-/telegraf-4.3.0.tgz#c9683192bdb81e7c7fbb04cf1ce750fb34de7149"
+  integrity sha512-MuDUtSMipzMzQp8fXbQx76jp4ZD70KREdnpH1idUzN9Zlgm6EzatBQFU4Ps0ipxtEmnBBdghBMumQwrjRe3eqg==
   dependencies:
-    debug "^4.0.1"
-    minimist "^1.2.0"
+    abort-controller "^3.0.0"
+    debug "^4.3.1"
+    minimist "^1.2.5"
     module-alias "^2.2.2"
-    node-fetch "^2.2.0"
-    sandwich-stream "^2.0.1"
-    telegram-typings "^3.6.0"
-
-telegram-typings@^3.6.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/telegram-typings/-/telegram-typings-3.6.1.tgz#1288d547f8694b61f1c01c2993e295f3114d9e25"
-  integrity sha512-njVv1EAhIZnmQVLocZEADYUyqA1WIXuVcDYlsp+mXua/XB0pxx+PKtMSPeZ/EE4wPWTw9h/hA9ASTT6yQelkiw==
+    node-fetch "^2.6.1"
+    p-timeout "^4.1.0"
+    safe-compare "^1.1.4"
+    sandwich-stream "^2.0.2"
+    typegram "^3.2.0"
 
 term-size@^2.1.0:
   version "2.2.1"
@@ -1331,6 +1371,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typegram@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/typegram/-/typegram-3.3.1.tgz#af1ca857350a270ed065fb708c19bab36e0d61a7"
+  integrity sha512-Y1bR17IZ9Shj1Ih8wTLtrmOOMHJ20ve0Bd5SPymmw53uO4WLp/JjNM55s2b6PEziBvMISRdCQSZ+m6JiUKEobA==
 
 typescript@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
Updated telegraf js to 4.3.0 and updated code, because 4.x versions have some breaking changes.